### PR TITLE
Update lodash dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/shakyShane/opt-merger",
   "dependencies": {
-    "lodash": "^2.4.1",
+    "lodash": "^3.10.1",
     "minimist": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
lodash@<3.0.0 is no longer maintained.

All tests pass when using lodash 3.10.1